### PR TITLE
Integrate Redux into current board functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11247,6 +11247,15 @@
         "strip-indent": "^1.0.1"
       }
     },
+    "redux": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.4.tgz",
+      "integrity": "sha512-vKv4WdiJxOWKxK0yRoaK3Y4pxxB0ilzVx6dszU2W8wLxlb2yikRph4iV/ymtdJ6ZxpBLFbyrxklnT5yBbQSl3Q==",
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "symbol-observable": "^1.2.0"
+      }
+    },
     "regenerate": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
@@ -12982,6 +12991,11 @@
         "unquote": "~1.1.1",
         "util.promisify": "~1.0.0"
       }
+    },
+    "symbol-observable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
     "symbol-tree": {
       "version": "3.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6102,9 +6102,9 @@
       "integrity": "sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ=="
     },
     "handlebars": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.2.0.tgz",
-      "integrity": "sha512-Kb4xn5Qh1cxAKvQnzNWZ512DhABzyFNmsaJf3OAkWNa4NkaqWcNI8Tao8Tasi0/F4JD9oyG0YxuFyvyR57d+Gw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.3.1.tgz",
+      "integrity": "sha512-c0HoNHzDiHpBt4Kqe99N8tdLPKAnGCQ73gYMPWtAYM4PwGnf7xl8PBUHJqh9ijlzt2uQKaSRxbXRt+rZ7M2/kA==",
       "requires": {
         "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
@@ -6242,6 +6242,14 @@
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "hoist-non-react-statics": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
+      "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+      "requires": {
+        "react-is": "^16.7.0"
       }
     },
     "hosted-git-info": {
@@ -11075,6 +11083,19 @@
       "version": "16.9.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
       "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw=="
+    },
+    "react-redux": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.1.1.tgz",
+      "integrity": "sha512-QsW0vcmVVdNQzEkrgzh2W3Ksvr8cqpAv5FhEk7tNEft+5pp7rXxAudTz3VOPawRkLIepItpkEIyLcN/VVXzjTg==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "hoist-non-react-statics": "^3.3.0",
+        "invariant": "^2.2.4",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.9.0"
+      }
     },
     "react-scripts": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
+    "react-redux": "^7.1.1",
     "react-scripts": "3.1.1"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
     "react-redux": "^7.1.1",
-    "react-scripts": "3.1.1"
+    "react-scripts": "3.1.1",
+    "redux": "^4.0.4"
   },
   "scripts": {
     "watch:sass": "node-sass src/sass/index.scss src/index.css -w",

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -2,8 +2,8 @@ export const addList = (title, listId) => {
   return {
     type: "ADD_LIST",
     payload: {
-      title: title,
-      listId: listId
+      title,
+      listId
     }
   };
 };
@@ -12,5 +12,16 @@ export const archiveList = listId => {
   return {
     type: "ARCHIVE_LIST",
     payload: listId
+  };
+};
+
+export const addCard = (title, cardId, listHome) => {
+  return {
+    type: "ADD_CARD",
+    payload: {
+      title,
+      cardId,
+      listHome
+    }
   };
 };

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,0 +1,13 @@
+export const addList = title => {
+  return {
+    type: "ADD_LIST",
+    payload: title
+  };
+};
+
+export const archiveList = title => {
+  return {
+    type: "ARCHIVE_LIST",
+    payload: title
+  };
+};

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,13 +1,16 @@
-export const addList = title => {
+export const addList = (title, listId) => {
   return {
     type: "ADD_LIST",
-    payload: title
+    payload: {
+      title: title,
+      listId: listId
+    }
   };
 };
 
-export const archiveList = title => {
+export const archiveList = listId => {
   return {
     type: "ARCHIVE_LIST",
-    payload: title
+    payload: listId
   };
 };

--- a/src/components/board/AddList.js
+++ b/src/components/board/AddList.js
@@ -6,7 +6,6 @@ class AddList extends React.Component {
   state = {
     mode: "prompt",
     listTitle: "",
-    inputValid: false,
     borderColor: "#555",
     spans: 0
   };
@@ -43,15 +42,21 @@ class AddList extends React.Component {
     if (!this.state.listTitle) {
       alert("Please enter a title.");
       return false;
-    } else if (!this.state.inputValid) {
-      alert(
-        `A list with the title "${this.state.listTitle}" already exists. Please try a different title.`
-      );
-      return false;
     }
 
+    // Generate a unique key and listId in the event of duplicate list titles
+    const generateListId = inputId => {
+      if (!this.props.lists.find(list => list.listId === inputId)) {
+        return inputId;
+      } else {
+        inputId = `${inputId}-duplicate`;
+        return generateListId(inputId);
+      }
+    };
+    let listId = generateListId(this.state.listTitle);
+
     // Submit input
-    this.props.addList(this.state.listTitle);
+    this.props.addList(this.state.listTitle, listId);
 
     // Clear input
     this.setState({ listTitle: "", inputValid: false, borderColor: "#555" });
@@ -62,33 +67,13 @@ class AddList extends React.Component {
 
   // Controlled input and validation to ensure unique list titles
   handleChange = e => {
-    //Check if user input matches existing list title
-    let inputUnique = true;
-    this.props.currentLists.forEach(list => {
-      if (e.target.value === list.title) {
-        inputUnique = false;
-      }
+    this.setState({
+      listTitle: e.target.value
     });
 
-    // After check, update state
-    inputUnique
-      ? this.setState({
-          listTitle: e.target.value,
-          inputValid: true,
-          borderColor: "#4fa644"
-        })
-      : this.setState({
-          listTitle: e.target.value,
-          inputValid: false,
-          borderColor: "red"
-        });
-
-    // Reset border color if input is empty
-    if (!e.target.value) {
-      this.setState({
-        borderColor: "#555"
-      });
-    }
+    e.target.value
+      ? this.setState({ borderColor: "#4fa644" })
+      : this.setState({ borderColor: "red" });
   };
 
   render() {

--- a/src/components/board/AddList.js
+++ b/src/components/board/AddList.js
@@ -1,4 +1,6 @@
 import React from "react";
+import { connect } from "react-redux";
+import { addList } from "../../actions";
 
 class AddList extends React.Component {
   state = {
@@ -49,7 +51,7 @@ class AddList extends React.Component {
     }
 
     // Submit input
-    this.props.onSubmit(this.state.listTitle);
+    this.props.addList(this.state.listTitle);
 
     // Clear input
     this.setState({ listTitle: "", inputValid: false, borderColor: "#555" });
@@ -134,4 +136,11 @@ class AddList extends React.Component {
   }
 }
 
-export default AddList;
+const mapStateToProps = state => {
+  return { lists: state.lists };
+};
+
+export default connect(
+  mapStateToProps,
+  { addList }
+)(AddList);

--- a/src/components/board/Board.js
+++ b/src/components/board/Board.js
@@ -1,16 +1,17 @@
 import AddList from "./AddList";
 import List from "./list/List";
 import React from "react";
+import { connect } from "react-redux";
 
 class Board extends React.Component {
-  state = { lists: [] };
+  //state = { lists: [] };
 
   // List constructor function
   List = function(title) {
     this.title = title;
     this.cards = [];
   };
-
+  /*
   // Update state with new list, setting the list title as the argument 'title'
   onListSubmit = title => {
     let currentLists = [...this.state.lists];
@@ -18,21 +19,23 @@ class Board extends React.Component {
     this.setState({ lists: currentLists });
   };
 
+
   // Iterate over lists, keep only the ones that have a title other than the function argument
   removeList = title => {
     let currentLists = [...this.state.lists];
     currentLists = currentLists.filter(list => list.title !== title);
     this.setState({ lists: currentLists });
   };
+  */
 
   // Function to create List components from state
   listsArray = () =>
-    this.state.lists.map(list => {
+    this.props.lists.map(list => {
       return (
         <List
           key={list.title}
           listTitle={list.title}
-          remove={this.removeList}
+          //remove={this.removeList}
         />
       );
     });
@@ -43,11 +46,15 @@ class Board extends React.Component {
         {this.listsArray()}
         <AddList
           onSubmit={this.onListSubmit}
-          currentLists={this.state.lists}
+          currentLists={this.props.lists}
         ></AddList>
       </div>
     );
   }
 }
 
-export default Board;
+const mapStateToProps = state => {
+  return { lists: state.lists };
+};
+
+export default connect(mapStateToProps)(Board);

--- a/src/components/board/Board.js
+++ b/src/components/board/Board.js
@@ -4,29 +4,19 @@ import React from "react";
 import { connect } from "react-redux";
 
 class Board extends React.Component {
-  //state = { lists: [] };
-
-  // List constructor function
-  List = function(title) {
-    this.title = title;
-    this.cards = [];
-  };
-
-  // Function to create List components from state
+  // Iterate over every list in state, return the non-archived ones, and make and array of List components out of them
   listsArray = () =>
-    this.props.lists.map(list => {
-      if (!list.archived) {
-        return (
-          <List key={list.listId} listTitle={list.title} listId={list.listId} />
-        );
-      }
-    });
+    this.props.lists
+      .filter(list => !list.archived)
+      .map(list => (
+        <List key={list.listId} listTitle={list.title} listId={list.listId} />
+      ));
 
   render() {
     return (
       <div className="board">
         {this.listsArray()}
-        <AddList onSubmit={this.onListSubmit}></AddList>
+        <AddList />
       </div>
     );
   }

--- a/src/components/board/Board.js
+++ b/src/components/board/Board.js
@@ -11,43 +11,22 @@ class Board extends React.Component {
     this.title = title;
     this.cards = [];
   };
-  /*
-  // Update state with new list, setting the list title as the argument 'title'
-  onListSubmit = title => {
-    let currentLists = [...this.state.lists];
-    currentLists.push(new this.List(title));
-    this.setState({ lists: currentLists });
-  };
-
-
-  // Iterate over lists, keep only the ones that have a title other than the function argument
-  removeList = title => {
-    let currentLists = [...this.state.lists];
-    currentLists = currentLists.filter(list => list.title !== title);
-    this.setState({ lists: currentLists });
-  };
-  */
 
   // Function to create List components from state
   listsArray = () =>
     this.props.lists.map(list => {
-      return (
-        <List
-          key={list.title}
-          listTitle={list.title}
-          //remove={this.removeList}
-        />
-      );
+      if (!list.archived) {
+        return (
+          <List key={list.listId} listTitle={list.title} listId={list.listId} />
+        );
+      }
     });
 
   render() {
     return (
       <div className="board">
         {this.listsArray()}
-        <AddList
-          onSubmit={this.onListSubmit}
-          currentLists={this.props.lists}
-        ></AddList>
+        <AddList onSubmit={this.onListSubmit}></AddList>
       </div>
     );
   }

--- a/src/components/board/list/AddCard.js
+++ b/src/components/board/list/AddCard.js
@@ -1,11 +1,14 @@
 import React from "react";
+import { connect } from "react-redux";
+import { addCard } from "../../../actions";
 
 class AddCard extends React.Component {
   // This component has two modes: "prompt" and "input." The "prompt" mode is the initial mode, basically a button with a label like "add new card." When the user clicks that button, the mode changes to "input," and the user can input and submit a new card and title.
   state = {
     mode: "prompt",
     backgroundColor: "",
-    cardTitle: ""
+    cardTitle: "",
+    borderColor: "#555"
   };
 
   // Hover effect (CSS's :hover pseudoselector wasn't creating the desired effect)
@@ -54,12 +57,29 @@ class AddCard extends React.Component {
   onFormSubmit = e => {
     e.preventDefault();
 
-    // Call parent component's onSubmit function if user has entered a card title
+    // Validate input
+    if (!this.state.cardTitle) {
+      alert("Please enter a card title.");
+      return false;
+    }
+
+    // Generate a unique key and cardId in the event of duplicate card titles
+    const generateCardId = inputId => {
+      if (!this.props.cards.find(card => card.cardId === inputId)) {
+        return inputId;
+      } else {
+        inputId = `${inputId}-duplicate`;
+        return generateCardId(inputId);
+      }
+    };
+    let cardId = generateCardId(this.state.cardTitle);
+
+    // Call addCard redux action if user has entered a card title
     if (this.state.cardTitle) {
-      this.props.onSubmit(this.state.cardTitle);
+      this.props.addCard(this.state.cardTitle, cardId, this.props.listHome);
 
       // Clear input, change mode
-      this.setState({ cardTitle: "", mode: "prompt" });
+      this.setState({ cardTitle: "", mode: "prompt", borderColor: "#555" });
       this.props.setSpansUpdateForCard(this.promptHeight);
     } else {
       return false;
@@ -69,6 +89,10 @@ class AddCard extends React.Component {
   // Controlled input handler
   handleChange = e => {
     this.setState({ cardTitle: e.target.value });
+
+    e.target.value
+      ? this.setState({ borderColor: "#4fa644" })
+      : this.setState({ borderColor: "red" });
   };
 
   render() {
@@ -118,4 +142,11 @@ class AddCard extends React.Component {
   }
 }
 
-export default AddCard;
+const mapStateToProps = state => {
+  return { cards: state.cards };
+};
+
+export default connect(
+  mapStateToProps,
+  { addCard }
+)(AddCard);

--- a/src/components/board/list/List.js
+++ b/src/components/board/list/List.js
@@ -6,7 +6,6 @@ import { archiveList } from "../../../actions";
 
 class List extends React.Component {
   state = {
-    cards: [],
     spans: 13
   };
 
@@ -51,21 +50,13 @@ class List extends React.Component {
     this.props.archiveList(this.props.listId);
   };
 
-  // Add new card handlers
-  Card = function(title) {
-    this.title = title;
-  };
-
-  addNewCard = title => {
-    let currentCards = [...this.state.cards];
-    currentCards.push(new this.Card(title));
-    this.setState({ cards: currentCards });
-  };
-
+  // Iterate over every card in state, return only the non-archived ones with a listHome corresponding to this list, and then make an array of Card components out of them
   cardsArray = () =>
-    this.state.cards.map(card => {
-      return <Card key={card.title} cardTitle={card.title} />;
-    });
+    this.props.cards
+      .filter(card => card.listHome === this.props.listId && !card.archived)
+      .map(card => (
+        <Card key={card.cardId} cardId={card.cardId} cardTitle={card.title} />
+      ));
 
   render() {
     return (
@@ -84,7 +75,7 @@ class List extends React.Component {
           {this.cardsArray()}
         </div>
         <AddCard
-          onSubmit={this.addNewCard}
+          listHome={this.props.listId}
           setSpansUpdate={this.setSpansUpdate}
           setSpansUpdateForCard={this.setSpansUpdateForCard}
         />
@@ -94,7 +85,7 @@ class List extends React.Component {
 }
 
 const mapStateToProps = state => {
-  return { lists: state.lists };
+  return { lists: state.lists, cards: state.cards };
 };
 export default connect(
   mapStateToProps,

--- a/src/components/board/list/List.js
+++ b/src/components/board/list/List.js
@@ -1,6 +1,8 @@
 import AddCard from "./AddCard";
 import Card from "./Card";
 import React from "react";
+import { connect } from "react-redux";
+import { archiveList } from "../../../actions";
 
 class List extends React.Component {
   state = {
@@ -45,8 +47,8 @@ class List extends React.Component {
   };
 
   // Event handler for when user clicks the remove button
-  removeList = () => {
-    this.props.remove(this.props.listTitle);
+  archiveList = () => {
+    this.props.archiveList(this.props.listId);
   };
 
   // Add new card handlers
@@ -72,7 +74,7 @@ class List extends React.Component {
         ref={this.listRef}
         style={{ gridRowEnd: `span ${this.state.spans}` }}
       >
-        <div className="list__remove" onClick={this.removeList}>
+        <div className="list__remove" onClick={this.archiveList}>
           &times;
         </div>
         <h2 className="list__heading" ref={this.headingRef}>
@@ -91,4 +93,10 @@ class List extends React.Component {
   }
 }
 
-export default List;
+const mapStateToProps = state => {
+  return { lists: state.lists };
+};
+export default connect(
+  mapStateToProps,
+  { archiveList }
+)(List);

--- a/src/index.js
+++ b/src/index.js
@@ -2,11 +2,11 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { Provider } from "react-redux";
 import { createStore } from "redux";
+import * as serviceWorker from "./serviceWorker";
 
 import "./index.css";
 import App from "./components/app/App";
 import reducers from "./reducers";
-import * as serviceWorker from "./serviceWorker";
 
 const store = createStore(reducers);
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,21 @@
 import React from "react";
 import ReactDOM from "react-dom";
+import { Provider } from "react-redux";
+import { createStore } from "redux";
+
 import "./index.css";
 import App from "./components/app/App";
+import reducers from "./reducers";
 import * as serviceWorker from "./serviceWorker";
 
-ReactDOM.render(<App />, document.getElementById("root"));
+const store = createStore(reducers);
+
+ReactDOM.render(
+  <Provider store={store}>
+    <App />
+  </Provider>,
+  document.getElementById("root")
+);
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.

--- a/src/reducers/cardsReducer.js
+++ b/src/reducers/cardsReducer.js
@@ -1,0 +1,16 @@
+export default (state = [], action) => {
+  switch (action.type) {
+    case "ADD_CARD":
+      return [
+        ...state,
+        {
+          title: action.payload.title,
+          cardId: action.payload.cardId,
+          listHome: action.payload.listHome,
+          archived: false
+        }
+      ];
+    default:
+      return state;
+  }
+};

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,0 +1,8 @@
+import { combineReducers } from "redux";
+import listsReducer from "./listsReducer";
+import cardsReducer from "./cardsReducer";
+
+export default combineReducers({
+  lists: listsReducer,
+  cards: cardsReducer
+});

--- a/src/reducers/listsReducer.js
+++ b/src/reducers/listsReducer.js
@@ -1,0 +1,10 @@
+export default (state = [], action) => {
+  switch (action.type) {
+    case "ADD_LIST":
+      return [...state, { title: action.payload }];
+    case "ARCHIVE_LIST":
+      return state;
+    default:
+      return state;
+  }
+};

--- a/src/reducers/listsReducer.js
+++ b/src/reducers/listsReducer.js
@@ -1,9 +1,22 @@
 export default (state = [], action) => {
   switch (action.type) {
     case "ADD_LIST":
-      return [...state, { title: action.payload }];
+      return [
+        ...state,
+        {
+          title: action.payload.title,
+          listId: action.payload.listId,
+          archived: false
+        }
+      ];
     case "ARCHIVE_LIST":
-      return state;
+      let currentLists = [...state];
+      currentLists.forEach(list => {
+        if (list.listId === action.payload) {
+          list.archived = true;
+        }
+      });
+      return currentLists;
     default:
       return state;
   }


### PR DESCRIPTION
We have Redux now! 

**NOTE:** Run ```npm install``` before running the app to get Redux and React-Redux going.

From a UI standpoint, the board works nearly the same as before. One UI change is that the user is now free to make as many lists of the same title as they want: a ```generateListId``` function within the AddList component handles list title conflicts, so two lists of the same title will each get unique ```key```s and ```listId``` props. 

The Board component renders lists differently now. It iterates over the entire store and renders only lists with the key-value pair ```archived: false```.  The X at the top-right corner of each list sets its list's ```archived``` prop to ```true```. When we create an archive later on, we can simply iterate over the entire store and render the lists with ```archived: true```.  

List components now render cards differently. In the store, the cards exist independently of lists but each has a ```listHome``` prop set to the ```listId``` of the list on which it was initially created. When a list renders cards, it iterates over the entire store and only renders the ones with a ```listHome``` equivalent to the list's ```listId```. Later on, to move a card, we can just modify its ```listHome``` value. A ```generateCardId``` function handles title conflicts and guarantees unique keys. Each card, like the lists, has an ```archived``` value, so we can do what Trello does and have separate card and list archives. 